### PR TITLE
Adding annotation points to every AST node

### DIFF
--- a/lib/Language/Mist/CGen.hs
+++ b/lib/Language/Mist/CGen.hs
@@ -38,8 +38,7 @@ cgen :: (Predicate r, Show r, Show a) =>
 cgen _ e@Unit{}    = (Head true,) <$> prim e
 cgen _ e@Number{}  = (Head true,) <$> prim e
 cgen _ e@Boolean{} = (Head true,) <$> prim e
-cgen _ e@Prim2{}   = (Head true,) <$> prim e -- TODO: should this be a lookup?
-                                      -- how should prims be handled?
+cgen _ e@Prim{}    = (Head true,) <$> prim e
 cgen env (Id x _)  = (Head true,) <$> single env x
 
 cgen env (If (Id y _) e1 e2 l) = do

--- a/lib/Language/Mist/Checker.hs
+++ b/lib/Language/Mist/Checker.hs
@@ -491,7 +491,7 @@ a <<: b = do
     (_, Just evar) -> do
       occurrenceCheck evar a
       instantiateR a evar
-    (_, _) -> error $ "TODO: this is a subtyping error" ++ show a ++ show b
+    (_, _) -> error $ "TODO: this is a subtyping error: " ++ show a ++ " <: " ++ show b
 
 -- DEBUGGING
 instantiateL :: EVar -> Type -> Context ()
@@ -642,6 +642,8 @@ typeCheckLet binding@(AnnBind{bindAnn = Just (ParsedAssume rType)}) e1 e2 tag ha
   result <- handleBody annBind c1 e2 tag
   modifyEnv $ dropEnvAfter newBinding
   pure result
+typeCheckLet AnnBind{bindAnn = Nothing} _ _ _ _ =
+  error "impossible: every binder should be annotated"
 
 -- | Carries out Hindley-Milner style let generalization on the existential variable.
 -- Also substitutes for all existentials that were added as annotations

--- a/lib/Language/Mist/Names.hs
+++ b/lib/Language/Mist/Names.hs
@@ -138,28 +138,23 @@ class Subable e a where
 instance Subable Type [Type] where
   _subst su = fmap (_subst su)
 
-instance Subable Type (ElaboratedType r a) where
-  _subst su (Left rType) = Left $ substReftType su rType
-  _subst su (Right typ) = Right $ _subst su typ
+instance Subable Type (ElaboratedAnnotation r a) where
+  _subst su (ElabRefined rType) = ElabRefined $ substReftType su rType
+  _subst su (ElabUnrefined typ) = ElabUnrefined $ _subst su typ
 
 instance Subable Type t => Subable Type (Expr t a) where
-  _subst _su e@Number{} = e
-  _subst _su e@Boolean{} = e
-  _subst _su e@Unit{} = e
-  _subst _su e@Id{} = e
-  _subst _su e@Prim{} = e
-  _subst su (If e e1 e2 l)
-    = If (_subst su e) (_subst su e1) (_subst su e2) l
-  _subst su (Let bind e1 e2 l)
-    = Let (_subst su bind) (_subst su e1) (_subst su e2) l
-  _subst su (App e1 e2 l)
-    = App (_subst su e1) (_subst su e2) l
-  _subst su (Lam bind e l)
-    = Lam (_subst su bind) (_subst su e) l
-  _subst su (TApp e typ l)
-    = TApp (_subst su e) (_subst su typ) l
-  _subst su (TAbs tvar e l)
-    = TAbs tvar (_subst (M.delete (unTV tvar) su) e) l
+  _subst su (AnnNumber n tag l) = AnnNumber n (_subst su tag) l
+  _subst su (AnnBoolean b tag l) = AnnBoolean b (_subst su tag) l
+  _subst su (AnnUnit tag l) = AnnUnit (_subst su tag) l
+  _subst su (AnnId var tag l) = AnnId var (_subst su tag) l
+  _subst su (AnnPrim op tag l) = AnnPrim op (_subst su tag) l
+  _subst su (AnnIf e1 e2 e3 tag l) = AnnIf (_subst su e1) (_subst su e2) (_subst su e3) (_subst su tag) l
+  _subst su (AnnLet x e1 e2 tag l) = AnnLet (_subst su x) (_subst su e1) (_subst su e2) (_subst su tag) l
+  _subst su (AnnApp e1 e2 tag l) = AnnApp (_subst su e1) (_subst su e2) (_subst su tag) l
+  _subst su (AnnLam x e tag l) = AnnLam (_subst su x) (_subst su e) (_subst su tag) l
+  _subst su (AnnTApp e typ tag l) = AnnTApp (_subst su e) typ (_subst su tag) l
+  _subst su (AnnTAbs tvar e tag l) = AnnTAbs tvar (_subst su' e) (_subst su tag) l
+    where su' = M.delete (unTV tvar) su
 
 instance Subable Type Type where
   _subst su t@(TVar (TV a)) = fromMaybe t $ M.lookup a su
@@ -172,26 +167,29 @@ instance Subable Type Type where
   _subst su (TCtor c t2) = TCtor c (_subst su t2)
   _subst su (TForall tvar t) = TForall tvar (_subst (M.delete (unTV tvar) su) t)
 
-instance Subable Type t => Subable Type (AnnBind t a) where
-  _subst su (AnnBind name t l) = AnnBind name (_subst su t) l
+instance Subable Type t => Subable Type (Bind t a) where
+  _subst su (AnnBind name tag l) = AnnBind name (_subst su tag) l
 
 instance Subable (Expr t a) (Expr t a) where
-  _subst _ e@Number{} = e
-  _subst _ e@Boolean{} = e
-  _subst _ e@Unit{} = e
-  _subst su e@(Id x _) = fromMaybe e $ M.lookup x su
-  _subst _su e@Prim{} = e
-  _subst su (If e1 e2 e3 loc) = If (_subst su e1) (_subst su e2) (_subst su e3) loc
-  _subst su (Let b e1 e2 loc) = Let b (_subst su' e1) (_subst su' e2) loc
-    where
-      su' = M.delete (bindId b) su
-  _subst su (App e1 e2 loc) = App (_subst su e1) (_subst su e2) loc
-  _subst su (Lam b e loc) = Lam b (_subst (M.delete (bindId b) su) e) loc
-  _subst su (TApp e typ loc) = TApp (_subst su e) typ loc
-  _subst su (TAbs alpha e loc) = TAbs alpha (_subst su e) loc
+  _subst _ e@AnnNumber{} = e
+  _subst _ e@AnnBoolean{} = e
+  _subst _ e@AnnUnit{} = e
+  _subst su e@(AnnId x _ _) = fromMaybe e $ M.lookup x su
+  _subst _su e@AnnPrim{} = e
+  _subst su (AnnIf e1 e2 e3 tag l) = AnnIf (_subst su e1) (_subst su e2) (_subst su e3) tag l
+  _subst su (AnnLet b e1 e2 tag l) = AnnLet b (_subst su' e1) (_subst su' e2) tag l
+    where su' = M.delete (bindId b) su
+  _subst su (AnnApp e1 e2 tag l) = AnnApp (_subst su e1) (_subst su e2) tag l
+  _subst su (AnnLam b e tag l) = AnnLam b (_subst su' e) tag l
+    where su' = M.delete (bindId b) su
+  _subst su (AnnTApp e typ tag l) = AnnTApp (_subst su e) typ tag l
+  _subst su (AnnTAbs alpha e tag l) = AnnTAbs alpha (_subst su e) tag l
+
+instance Subable Type a => Subable Type (Maybe a) where
+  _subst su = fmap (_subst su)
 
 instance Predicate r => Subable Id r where
-  _subst su r = M.foldrWithKey (\x y r' -> varSubst x y r') r su
+  _subst su r = M.foldrWithKey varSubst r su
 
 
 --------------------------------------------------------------------------------
@@ -215,9 +213,9 @@ instance Monad m => MonadFresh (FreshT m) where
         n' = n + 1
     FreshT (put $ FreshState n')
     return name'
-  -- popId = FreshT (modify $ \(FreshState m n g) ->
+  -- popAnnId = FreshT (modify $ \(FreshState m n g) ->
   --   FreshState (M.adjust safeTail (head g) m) n (tail g))
-  -- lookupId name = FreshT (gets $ fmap head . M.lookup name . nameMap)
+  -- lookupAnnId name = FreshT (gets $ fmap head . M.lookup name . nameMap)
 
 emptyFreshState :: FreshState
 emptyFreshState = FreshState { freshInt = 0 }
@@ -254,36 +252,43 @@ class Uniqable a where
   unique :: a -> UniqableContext a
 
 instance (Uniqable t) => Uniqable (Expr t a) where
-  unique (Lam b body l) = do
+  unique (AnnLam b body tag l) = do
+    tag' <- unique tag
     b' <- unique b
     body' <- unique body
     modify $ popNewName (bindId b)
-    pure $ Lam b' body' l
-  unique (Let bind e1 e2 l) = do
+    pure $ AnnLam b' body' tag' l
+  unique (AnnLet bind e1 e2 tag l) = do
+    tag' <- unique tag
     bind' <- unique bind
     e1' <- unique e1
     e2' <- unique e2
     modify $ popNewName (bindId bind)
-    pure $ Let bind' e1' e2' l
-  unique (Id id l) = Id . fromJust <$> gets (lookupNewName id) <*> pure l
+    pure $ AnnLet bind' e1' e2' tag' l
+  unique (AnnId id tag l) = AnnId . fromJust <$> gets (lookupNewName id) <*> unique tag <*> pure l
 
-  unique e@Number{} = pure e
-  unique e@Boolean{} = pure e
-  unique e@Unit{} = pure e
-  unique e@Prim{} = pure e
-  unique (If e1 e2 e3 l) =
-    If <$> unique e1 <*> unique e2 <*> unique e3 <*> pure l
-  unique (App e1 e2 l) =
-    App <$> unique e1 <*> unique e2 <*> pure l
-  unique (TApp e t l) =
-    TApp <$> unique e <*> unique t <*> pure l
-  unique (TAbs tvar e l) = do
+  unique (AnnNumber n tag l) = AnnNumber n <$> unique tag <*> pure l
+  unique (AnnBoolean b tag l) = AnnBoolean b <$> unique tag <*> pure l
+  unique (AnnUnit tag l) = AnnUnit <$> unique tag <*> pure l
+  unique (AnnPrim op tag l) = AnnPrim op <$> unique tag <*> pure l
+  unique (AnnIf e1 e2 e3 tag l) =
+    AnnIf <$> unique e1 <*> unique e2 <*> unique e3 <*> unique tag <*> pure l
+  unique (AnnApp e1 e2 tag l) =
+    AnnApp <$> unique e1 <*> unique e2 <*> unique tag <*> pure l
+  unique (AnnTApp e t tag l) =
+    AnnTApp <$> unique e <*> unique t <*> unique tag <*> pure l
+  unique (AnnTAbs tvar e tag l) = do
+    tag' <- unique tag
     tvar' <- uniquifyBindingTVar tvar
     e' <- unique e
     modify $ popNewName (unTV tvar)
-    pure $ TAbs tvar' e' l
+    pure $ AnnTAbs tvar' e' tag' l
 
-instance Uniqable e => Uniqable (RType e a) where
+instance Uniqable a => Uniqable (Maybe a) where
+  unique (Just a) = Just <$> unique a
+  unique Nothing = pure Nothing
+
+instance (Uniqable r) => Uniqable (RType r a) where
   unique (RBase bind typ expr) = do
     bind' <- unique bind
     typ' <- unique typ
@@ -329,7 +334,7 @@ instance Uniqable Type where
     modify $ popNewName (unTV tvar)
     pure $ TForall tvar' t'
 
-instance Uniqable r => Uniqable (ParsedType r a) where
+instance (Uniqable r) => Uniqable (ParsedAnnotation r a) where
   unique (ParsedCheck rtype) = ParsedCheck <$> unique rtype
   unique (ParsedAssume rtype) = ParsedAssume <$> unique rtype
   unique ParsedInfer = pure ParsedInfer
@@ -337,18 +342,12 @@ instance Uniqable r => Uniqable (ParsedType r a) where
 instance Uniqable () where
   unique _ = pure ()
 
-instance Uniqable (Bind a) where
-  unique (Bind name l) = do
+instance Uniqable t => Uniqable (Bind t a) where
+  unique (AnnBind name tag l) = do
     name' <- refreshId name
+    tag' <- unique tag
     modify $ pushNewName name name'
-    pure $ Bind name' l
-
-instance Uniqable t => Uniqable (AnnBind t a) where
-  unique (AnnBind name t l) = do
-    name' <- refreshId name
-    t' <- unique t
-    modify $ pushNewName name name'
-    pure $ AnnBind name' t' l
+    pure $ AnnBind name' tag' l
 
 uniquifyBindingTVar :: TVar -> UniqableContext TVar
 uniquifyBindingTVar (TV name) = do

--- a/lib/Language/Mist/Names.hs
+++ b/lib/Language/Mist/Names.hs
@@ -12,7 +12,6 @@ module Language.Mist.Names
 
   , cSEPARATOR
 
-
   , varNum
 
   , FreshT
@@ -148,8 +147,7 @@ instance Subable Type t => Subable Type (Expr t a) where
   _subst _su e@Boolean{} = e
   _subst _su e@Unit{} = e
   _subst _su e@Id{} = e
-  _subst su (Prim2 op e1 e2 l)
-    = Prim2 op (_subst su e1) (_subst su e2) l
+  _subst _su e@Prim{} = e
   _subst su (If e e1 e2 l)
     = If (_subst su e) (_subst su e1) (_subst su e2) l
   _subst su (Let bind e1 e2 l)
@@ -182,7 +180,7 @@ instance Subable (Expr t a) (Expr t a) where
   _subst _ e@Boolean{} = e
   _subst _ e@Unit{} = e
   _subst su e@(Id x _) = fromMaybe e $ M.lookup x su
-  _subst su (Prim2 p e1 e2 loc) = Prim2 p (_subst su e1) (_subst su e2) loc
+  _subst _su e@Prim{} = e
   _subst su (If e1 e2 e3 loc) = If (_subst su e1) (_subst su e2) (_subst su e3) loc
   _subst su (Let b e1 e2 loc) = Let b (_subst su' e1) (_subst su' e2) loc
     where
@@ -272,8 +270,7 @@ instance (Uniqable t) => Uniqable (Expr t a) where
   unique e@Number{} = pure e
   unique e@Boolean{} = pure e
   unique e@Unit{} = pure e
-  unique (Prim2 op e1 e2 l) =
-    Prim2 op <$> unique e1 <*> unique e2 <*> pure l
+  unique e@Prim{} = pure e
   unique (If e1 e2 e3 l) =
     If <$> unique e1 <*> unique e2 <*> unique e3 <*> pure l
   unique (App e1 e2 l) =

--- a/lib/Language/Mist/Names.hs
+++ b/lib/Language/Mist/Names.hs
@@ -152,7 +152,7 @@ instance Subable Type t => Subable Type (Expr t a) where
   _subst su (AnnLet x e1 e2 tag l) = AnnLet (_subst su x) (_subst su e1) (_subst su e2) (_subst su tag) l
   _subst su (AnnApp e1 e2 tag l) = AnnApp (_subst su e1) (_subst su e2) (_subst su tag) l
   _subst su (AnnLam x e tag l) = AnnLam (_subst su x) (_subst su e) (_subst su tag) l
-  _subst su (AnnTApp e typ tag l) = AnnTApp (_subst su e) typ (_subst su tag) l
+  _subst su (AnnTApp e typ tag l) = AnnTApp (_subst su e) (_subst su typ) (_subst su tag) l
   _subst su (AnnTAbs tvar e tag l) = AnnTAbs tvar (_subst su' e) (_subst su tag) l
     where su' = M.delete (unTV tvar) su
 

--- a/lib/Language/Mist/Normalizer.hs
+++ b/lib/Language/Mist/Normalizer.hs
@@ -36,11 +36,11 @@ anf (Let x e b l) = do
   e' <- anf e
   b' <- anf b
   pure $ Let (first Just x) e' b' l
-anf (Prim2 o e1 e2 l) = do
-  (bs, e1') <- imm e1
-  (bs', e2') <- imm e2
-  let bs'' = bs' ++ bs
-  pure $ stitch bs'' (Prim2 o e1' e2' l)
+-- anf (Prim2 o e1 e2 l) = do
+--   (bs, e1') <- imm e1
+--   (bs', e2') <- imm e2
+--   let bs'' = bs' ++ bs
+--   pure $ stitch bs'' (Prim2 o e1' e2' l)
 anf (If c e1 e2 l) = do
   (bs, c') <- imm c
   e1' <- anf e1
@@ -86,12 +86,12 @@ imm e@Unit{} = immExp e
 imm e@Number{} = immExp e
 imm e@Boolean{} = immExp e
 imm (Id x l) = pure ([], Id x l)
-imm (Prim2 o e1 e2 l) = do
-  (bs, v1) <- imm e1
-  (bs', v2) <- imm e2
-  x <- freshBind l
-  let bs'' = (x, (Prim2 o v1 v2 l, l)) : (bs ++ bs')
-  pure (bs'', mkId x l)
+-- imm (Prim2 o e1 e2 l) = do
+--   (bs, v1) <- imm e1
+--   (bs', v2) <- imm e2
+--   x <- freshBind l
+--   let bs'' = (x, (Prim2 o v1 v2 l, l)) : (bs ++ bs')
+--   pure (bs'', mkId x l)
 
 -- imm i (Tuple e1 e2 l)   = (i'', bs', mkId x l)
 --   where

--- a/lib/Language/Mist/Parser.hs
+++ b/lib/Language/Mist/Parser.hs
@@ -206,19 +206,26 @@ mkApps = L.foldl1' (\e1 e2 -> App e1 e2 (stretch [e1, e2]))
 
 binops :: (Unannotated a) => [[Operator Parser (Bare a)]]
 binops =
-  [ [ InfixL (symbol "*"  *> pure (op Times))
+  [ [ InfixL (pure op <*> primitive Times "*")
     ]
-  , [ InfixL (symbol "+"  *> pure (op Plus))
-    , InfixL (symbol "-"  *> pure (op Minus))
+  , [ InfixL (pure op <*> primitive Plus "+")
+    , InfixL (pure op <*> primitive Minus "-")
     ]
-  , [ InfixL (symbol "==" *> pure (op Equal))
-    , InfixL (symbol ">"  *> pure (op Greater))
-    , InfixL (symbol "<=" *> pure (op Lte))
-    , InfixL (symbol "<"  *> pure (op Less))
+  , [ InfixL (pure op <*> primitive Equal "==")
+    , InfixL (pure op <*> primitive Greater ">")
+    , InfixL (pure op <*> primitive Lte "<=")
+    , InfixL (pure op <*> primitive Less "<")
     ]
   ]
   where
-    op o e1 e2 = Prim2 o e1 e2 (stretch [e1, e2])
+    op o e1 e2 = App (App o e1 (stretch [e1, o])) e2 (stretch [e1, e2])
+
+primitive :: (Unannotated a) => Prim -> String -> Parser (Bare a)
+primitive prim primSymbol = do
+  p1 <- getPosition
+  symbol primSymbol
+  p2 <- getPosition
+  pure $ Prim prim (SS p1 p2)
 
 idExpr :: (Unannotated a) => Parser (Bare a)
 idExpr = uncurry Id <$> identifier

--- a/lib/Language/Mist/Parser.hs
+++ b/lib/Language/Mist/Parser.hs
@@ -378,3 +378,6 @@ exprAddParsedInfers = goE
     goE (AnnTAbs tvar e _ l) = TAbs tvar (goE e) l
 
     goB (AnnBind x _ l) = AnnBind x (Just ParsedInfer) l
+
+bindsExpr :: [(Bind t a, Expr t a)] -> Expr t a -> t -> a -> Expr t a
+bindsExpr bs e t l = foldr (\(x, e1) e2 -> AnnLet x e1 e2 t l) e bs

--- a/lib/Language/Mist/Runner.hs
+++ b/lib/Language/Mist/Runner.hs
@@ -34,7 +34,7 @@ act _h f = do
   let r = mist e
   case r of
     Right t -> do
-      let c = generateConstraints (anormal t)
+      let c = generateConstraints (anormal (annotate t TUnit))
       solverResult <- print c >> solve c
       print solverResult
       case F.resStatus solverResult of

--- a/lib/Language/Mist/Runner.hs
+++ b/lib/Language/Mist/Runner.hs
@@ -47,7 +47,7 @@ esHandle :: Handle -> ([UserError] -> IO a) -> [UserError] -> IO a
 esHandle h exitF es = renderErrors es >>= hPutStrLn h >> exitF es
 
 -----------------------------------------------------------------------------------
-mist :: BareExpr -> Result (ElaboratedExpr R SourceSpan)
+mist :: SSParsedExpr -> Result (ElaboratedExpr R SourceSpan)
 -----------------------------------------------------------------------------------
 mist expr = do
   case wellFormed expr of

--- a/lib/Language/Mist/Runner.hs
+++ b/lib/Language/Mist/Runner.hs
@@ -17,7 +17,6 @@ import qualified Language.Fixpoint.Horn.Types as HC
 import qualified Language.Fixpoint.Types as F
 
 import Text.Megaparsec.Pos (initialPos) -- NOTE: just for debugging
-import Debug.Trace
 
 type R = HC.Pred
 
@@ -55,6 +54,6 @@ mist expr = do
       let uniqueExpr = uniquify expr
       let predExpr = parsedExprPredToFixpoint uniqueExpr
       result <- elaborate predExpr
-      !_ <- traceM $ pprint result
+      -- !_ <- traceM $ pprint result
       pure result
     errors -> Left errors

--- a/lib/Language/Mist/ToFixpoint.hs
+++ b/lib/Language/Mist/ToFixpoint.hs
@@ -23,7 +23,7 @@ import qualified Language.Fixpoint.Types.Config as C
 import qualified Language.Fixpoint.Types as F
 import qualified Language.Fixpoint.Horn.Types as HC
 import qualified Language.Fixpoint.Horn.Solve as S
-import System.Console.CmdArgs.Verbosity
+-- import System.Console.CmdArgs.Verbosity
 
 -- | Solves the subtyping constraints we got from CGen.
 

--- a/lib/Language/Mist/ToFixpoint.hs
+++ b/lib/Language/Mist/ToFixpoint.hs
@@ -27,14 +27,14 @@ import System.Console.CmdArgs.Verbosity
 
 -- | Solves the subtyping constraints we got from CGen.
 
-solve :: M.Constraint HC.Pred -> IO (F.Result Integer)
+solve :: NNF HC.Pred -> IO (F.Result Integer)
 solve constraints = {-setVerbosity Loud >>-} S.solve cfg (HC.Query [] (collectKVars fixpointConstraint) fixpointConstraint mempty mempty)
   where
     fixpointConstraint = toHornClause constraints
     cfg = C.defConfig { C.eliminate = C.Existentials } -- , C.save = True }
 
 -- TODO: HC.solve requires () but should take any type
-toHornClause :: Constraint HC.Pred -> HC.Cstr ()
+toHornClause :: NNF HC.Pred -> HC.Cstr ()
 toHornClause c = c'
   where c' = toHornClause' c
 
@@ -90,45 +90,33 @@ typeToSort (TForall{}) = error "TODO?"
 --------------------------------------------------------------------
 -- Expressions
 --------------------------------------------------------------------
-exprToFixpoint :: M.Expr r a -> F.Expr
-exprToFixpoint (Number n _)       = F.ECon (F.I n)
-exprToFixpoint (Boolean True _)   = F.PTrue
-exprToFixpoint (Boolean False _)  = F.PFalse
-exprToFixpoint (Id x _)           = F.EVar (fromString x)
-exprToFixpoint (Prim _ _)         = error "primitives should be handled by appToFixpoing"
-exprToFixpoint (If e1 e2 e3 _)    =
+exprToFixpoint :: M.Expr t a -> F.Expr
+exprToFixpoint (AnnNumber n _ _)       = F.ECon (F.I n)
+exprToFixpoint (AnnBoolean True _ _)   = F.PTrue
+exprToFixpoint (AnnBoolean False _ _)  = F.PFalse
+exprToFixpoint (AnnId x _ _)           = idToFix x
+exprToFixpoint (AnnPrim _ _ _)         = error "primitives should be handled by appToFixpoing"
+exprToFixpoint (AnnIf e1 e2 e3 _ _)    =
   F.EIte (exprToFixpoint e1) (exprToFixpoint e2) (exprToFixpoint e3)
-exprToFixpoint e@App{}            =
-  appToFixpoint e
-exprToFixpoint Let{}              =
-  error "lets are currently unsupported inside reifnements"
-exprToFixpoint (Unit _)           = F.EVar (fromString "()")
--- exprToFixpoint (Tuple e1 e2 _)    =
---   F.EApp (F.EApp (F.EVar $ fromString "(,)")
---                  (exprToFixpoint e1))
---        (exprToFixpoint e2)
--- exprToFixpoint (GetItem e Zero _) =
---   F.EApp (F.EVar $ fromString "Pi0") (exprToFixpoint e)
--- exprToFixpoint (GetItem e One _)  =
---   F.EApp (F.EVar $ fromString "Pi1") (exprToFixpoint e)
---   -- To translate Lambdas we need to keep around the sorts of each Expr. We
---   -- can do this in Core, but doing it in Expr seems like it's not work it.
-exprToFixpoint (Lam _bs _e2 _)      = error "TODO exprToFixpoint"
-exprToFixpoint (TApp _e _typ _)      = error "TODO exprToFixpoint"
-exprToFixpoint (TAbs _tvar _e _)      = error "TODO exprToFixpoint"
+exprToFixpoint e@AnnApp{} = appToFixpoint e
+exprToFixpoint AnnLet{} = error "lets are currently unsupported inside refinements"
+exprToFixpoint (AnnUnit _ _)           = F.EVar (fromString "()")
+exprToFixpoint (AnnLam _bs _e2 _ _)      = error "TODO exprToFixpoint"
+exprToFixpoint (AnnTApp _e _typ _ _)      = error "TODO exprToFixpoint"
+exprToFixpoint (AnnTAbs _tvar _e _ _)      = error "TODO exprToFixpoint"
 
     -- case prim2ToFixpoint o of
     -- Left brel -> F.PAtom brel (exprToFixpoint e1) (exprToFixpoint e2)
     -- Right bop -> F.EBin bop (exprToFixpoint e1) (exprToFixpoint e2)
 
-appToFixpoint :: M.Expr r a -> F.Expr
+appToFixpoint :: M.Expr t a -> F.Expr
 appToFixpoint e =
   case e of
-    App (App (Prim op _) e1 _) e2 _ ->
+    AnnApp (AnnApp (AnnPrim op _ _) e1 _ _) e2 _ _ ->
       binopToFixpoint op e1 e2
-    App (App (TApp (Prim op _) _ _) e1 _) e2 _ ->
+    AnnApp (AnnApp (AnnTApp (AnnPrim op _ _) _ _ _) e1 _ _) e2 _ _ ->
       binopToFixpoint op e1 e2
-    App f x _ ->
+    AnnApp f x _ _ ->
       F.EApp (exprToFixpoint f) (exprToFixpoint x)
     _ -> error "non-application"
 
@@ -169,17 +157,17 @@ instance Predicate HC.Pred where
   varSubst x y (HC.PAnd ps) =
     HC.PAnd $ fmap (varSubst x y) ps
 
-  prim e@Unit{} = equalityPrim e TUnit
-  prim e@Number{} = equalityPrim e TInt
-  prim e@Boolean{} = equalityPrim e TBool
-  prim (Prim op l) = primOp op l
+  prim e@AnnUnit{} = equalityPrim e TUnit
+  prim e@AnnNumber{} = equalityPrim e TInt
+  prim e@AnnBoolean{} = equalityPrim e TBool
+  prim (AnnPrim op _ l) = primOp op l
   prim _ = error "prim on non primitive"
 
-equalityPrim :: (MonadFresh m) => Expr r a -> Type -> m (RType HC.Pred a)
+equalityPrim :: (MonadFresh m) => M.Expr t a -> Type -> m (RType HC.Pred a)
 equalityPrim e typ = do
-  let l = extract e
+  let l = extractLoc e
   vv <- refreshId $ "VV" ++ MN.cSEPARATOR
-  let reft = HC.Reft $ F.PAtom F.Eq (exprToFixpoint (Id vv l)) (exprToFixpoint e)
+  let reft = HC.Reft $ F.PAtom F.Eq (idToFix vv) (exprToFixpoint e)
   pure $ RBase (M.Bind vv l) typ reft
 
 primOp :: (MonadFresh m) => Prim -> a -> m (RType HC.Pred a)
@@ -214,13 +202,15 @@ primOp op l =
       let reft = HC.Reft $ F.PAtom F.Eq (idToFix v) (oper (idToFix x) (idToFix y))
       let returnType = RBase (Bind v l) typ2 reft
       pure $ RFun (Bind x l) (trivialBase typ1 v1) (RFun (Bind y l) (trivialBase typ1 v2) returnType)
-    idToFix x = exprToFixpoint (Id x l)
     trivialBase typ x = RBase (Bind x l) typ true
 
 
 -- | Converts a ParsedExpr's predicates from Exprs to Fixpoint Exprs
-parsedExprPredToFixpoint :: ParsedExpr (Expr r a) a -> ParsedExpr HC.Pred a
-parsedExprPredToFixpoint = first $ first (HC.Reft . exprToFixpoint)
+parsedExprPredToFixpoint :: ParsedExpr (Expr t a) a -> ParsedExpr HC.Pred a
+parsedExprPredToFixpoint = first $ fmap (first (HC.Reft . exprToFixpoint))
+
+idToFix :: Id -> F.Expr
+idToFix x = F.EVar (fromString x)
 
 
 ------------------------------------------------------------------------------

--- a/lib/Language/Mist/Types.hs
+++ b/lib/Language/Mist/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 module Language.Mist.Types
@@ -17,40 +18,44 @@ module Language.Mist.Types
   , RType (..)
 
   -- * Abstract syntax of Mist
-  , Expr  (..)
-  , Bind  (..)
-  , Def
+  , Expr (..)
+  , Bind (..)
 
-  , ParsedType (..)
-  , ParsedExpr, ParsedAnnBind, ParsedDef
+  , pattern Number
+  , pattern Boolean
+  , pattern Unit
+  , pattern Id
+  , pattern Prim
+  , pattern If
+  , pattern Let
+  , pattern Lam
+  , pattern App
+  , pattern TApp
+  , pattern TAbs
+  , pattern Bind
 
-  , ElaboratedType
-  , pattern ElabUnrefined, pattern ElabRefined
-  , ElaboratedExpr, ElaboratedAnnBind
+  , ParsedAnnotation (..)
+  , ParsedExpr, ParsedBind
 
-  , AnfType
-  , AnfExpr, AnfAnnBind
+  , ElaboratedAnnotation (..)
+  , ElaboratedExpr, ElaboratedBind
+
+  , AnfExpr
   , ImmExpr
-  , Unannotated (..)
-
-  , AnnBind (..)
-  , aBindType
-  , Binder (..)
 
   , Prim (..)
 
-  , extract
+  , extractLoc, extractAnn
   , unTV
-
   , bindsExpr
-  , annotateBinding
 
   , eraseRType
 
-  , Constraint (..)
+  , NNF (..)
   , Predicate (..)
 
   , MonadFresh (..)
+  , Default (..)
   ) where
 
 import GHC.Exts (IsString(..))
@@ -83,108 +88,132 @@ data Prim
   | Lte
   | Equal
   | And
-  deriving (Show, Read, Eq)
+  deriving (Show, Eq)
 
 -- | Mist expressions
--- Parameterized by the type of type annotations
+-- Parameterized by the type of annotations
 -- and the extra data.
 data Expr t a
-  = Number  !Integer                               a
-  | Boolean !Bool                                  a
-  | Unit                                           a
-  | Id      !Id                                    a
-  | Prim    !Prim                                  a
-  | If      !(Expr t a)    !(Expr t a) !(Expr t a) a
-  | Let     !(AnnBind t a) !(Expr t a) !(Expr t a) a
-  | App     !(Expr t a)    !(Expr t a)             a
-  | Lam     !(AnnBind t a) !(Expr t a)             a
-  | TApp    !(Expr t a)    !Type                   a
-  | TAbs    TVar           !(Expr t a)             a
-  deriving (Show, Functor, Read, Eq)
+  = AnnNumber !Integer !t !a
+  | AnnBoolean !Bool !t !a
+  | AnnUnit !t !a
+  | AnnId !Id !t !a
+  | AnnPrim !Prim !t !a
+  | AnnIf !(Expr t a) !(Expr t a) !(Expr t a) !t !a
+  | AnnLet !(Bind t a) !(Expr t a) !(Expr t a) !t !a
+  | AnnApp !(Expr t a) !(Expr t a) !t !a
+  | AnnLam !(Bind t a) !(Expr t a) !t !a
+  | AnnTApp !(Expr t a) !Type !t !a
+  | AnnTAbs TVar !(Expr t a) !t !a
+  deriving (Show, Functor, Eq)
+
+data Bind t a = AnnBind
+  { bindId :: !Id
+  , bindAnn :: !t
+  , bindTag :: !a
+  }
+  deriving (Show, Functor, Eq)
+
+pattern Number :: (Default t) => Integer -> a -> Expr t a
+pattern Number n l <- AnnNumber n _ l
+  where Number n l = AnnNumber n defaultVal l
+pattern Boolean :: (Default t) => Bool -> a -> Expr t a
+pattern Boolean b l <- AnnBoolean b _ l
+  where Boolean b l = AnnBoolean b defaultVal l
+pattern Unit :: (Default t) => a -> Expr t a
+pattern Unit l <- AnnUnit _ l
+  where Unit l = AnnUnit defaultVal l
+pattern Id :: (Default t) => Id -> a -> Expr t a
+pattern Id x l <- AnnId x _ l
+  where Id x l = AnnId x defaultVal l
+pattern Prim :: (Default t) => Prim -> a -> Expr t a
+pattern Prim op l <- AnnPrim op _ l
+  where Prim op l = AnnPrim op defaultVal l
+pattern If :: (Default t) => Expr t a -> Expr t a -> Expr t a -> a -> Expr t a
+pattern If e1 e2 e3 l <- AnnIf e1 e2 e3 _ l
+  where If e1 e2 e3 l = AnnIf e1 e2 e3 defaultVal l
+pattern Let :: (Default t) => Bind t a -> Expr t a -> Expr t a -> a -> Expr t a
+pattern Let x e1 e2 l <- AnnLet x e1 e2 _ l
+  where Let x e1 e2 l = AnnLet x e1 e2 defaultVal l
+pattern Lam :: (Default t) => Bind t a -> Expr t a -> a -> Expr t a
+pattern Lam x e l <- AnnLam x e _ l
+  where Lam x e l = AnnLam x e defaultVal l
+pattern App :: (Default t) => Expr t a -> Expr t a -> a -> Expr t a
+pattern App e1 e2 l <- AnnApp e1 e2 _ l
+  where App e1 e2 l = AnnApp e1 e2 defaultVal l
+pattern TApp :: (Default t) => Expr t a -> Type -> a -> Expr t a
+pattern TApp e typ l <- AnnTApp e typ _ l
+  where TApp e typ l = AnnTApp e typ defaultVal l
+pattern TAbs :: (Default t) => TVar -> Expr t a -> a -> Expr t a
+pattern TAbs tvar e l <- AnnTAbs tvar e _ l
+  where TAbs tvar e l = AnnTAbs tvar e defaultVal l
+
+pattern Bind :: (Default t) => Id -> a -> Bind t a
+pattern Bind id tag <- AnnBind id _ tag
+  where Bind id tag = AnnBind id defaultVal tag
+
+-- | Refinement types
+-- | - refinements are expressions of type Bool
+-- |
+-- | ```
+-- | τ ::= { v:τ | r }   -- a refinement on an RType
+-- |     | { v:b | r }   -- a refinement on a base Type
+-- |     | x:τ -> τ      -- a pi type
+-- |     | ∀a.τ
+-- | ```
+-- |
+-- | This allows us to bind functions as in LH `--higherorder`
+-- |   {f : { v:_ | v < 0 } -> { v:_ | v > 0} | f 0 = 0}
+
+data RType r a
+  = RBase !(Bind () a) Type !r
+  | RFun !(Bind () a) !(RType r a) !(RType r a)
+  | RIFun !(Bind () a) !(RType r a) !(RType r a)
+  | RRTy !(Bind () a) !(RType r a) r
+  | RForall TVar !(RType r a)
+  deriving (Show, Functor)
+
+data Type = TVar TVar           -- a
+          | TUnit               -- 1
+          | TInt                -- Int
+          | TBool               -- Bool
+          | Type :=> Type       -- t1 => t2
+          | TCtor Ctor [Type]   -- Ctor [t1,...,tn]
+          | TForall TVar Type   -- ∀a.t
+          deriving (Eq, Ord, Show, Read)
+
+newtype Ctor = CT Id deriving (Eq, Ord, Show, Read)
+
+newtype TVar = TV Id deriving (Eq, Ord, Show, Read)
 
 -- | The type of Mist type annotations after parsing
 -- r is the type of refinements
-data ParsedType r a
-  = ParsedCheck  !(RType r a)
+data ParsedAnnotation r a
+  = ParsedCheck !(RType r a)
   | ParsedAssume !(RType r a)
   | ParsedInfer
-  deriving (Functor)
+  deriving (Functor, Show)
 
-type ParsedExpr r a = Expr (ParsedType r a) a
-type ParsedAnnBind r a = AnnBind (ParsedType r a) a
-type ParsedDef r a = Def (ParsedType r a) a
+type ParsedExpr r a = Expr (Maybe (ParsedAnnotation r a)) a
+type ParsedBind r a = Bind (Maybe (ParsedAnnotation r a)) a
 
 -- | The type of Mist type annotations after elaboration
 -- r is the type of refinements
-type ElaboratedType r a = Either (RType r a) Type
+data ElaboratedAnnotation r a
+  = ElabRefined !(RType r a)
+  | ElabUnrefined !Type
+  deriving (Functor, Show)
 
-pattern ElabRefined :: RType r a -> ElaboratedType r a
-pattern ElabRefined r = Left r
+type ElaboratedExpr r a = Expr (Maybe (ElaboratedAnnotation r a)) a
+type ElaboratedBind r a = Bind (Maybe (ElaboratedAnnotation r a)) a
 
-pattern ElabUnrefined :: Type -> ElaboratedType r a
-pattern ElabUnrefined t = Right t
+type AnfExpr t a = Expr t a
+type ImmExpr t a = Expr t a
 
-type ElaboratedExpr r a = Expr (ElaboratedType r a) a
-type ElaboratedAnnBind r a = AnnBind (ElaboratedType r a) a
+bindsExpr :: [(Bind t a, Expr t a)] -> Expr t a -> t -> a -> Expr t a
+bindsExpr bs e t l = foldr (\(x, e1) e2 -> AnnLet x e1 e2 t l) e bs
 
-type AnfType t a = Maybe t
-type AnfAnnBind t a = AnnBind (AnfType t a ) a
-
-data Bind a = Bind
-  { _bindId :: !Id
-  , _bindLabel :: a
-  }
-  deriving (Show, Functor, Read, Eq)
-
--- | Annotated Bindings parameterized by the type of the type annotation
-data AnnBind t a = AnnBind
-  { _aBindId :: !Id
-  , _aBindType :: t
-  , _aBindLabel :: a
-  }
-  deriving (Show, Functor, Read, Eq)
-
-aBindType = _aBindType
-
-class Binder b where
-  bindId :: b a -> Id
-  bindLabel :: b a -> a
-
-instance Binder Bind where
-  bindId = _bindId
-  bindLabel = _bindLabel
-
-instance Binder (AnnBind t) where
-  bindId = _aBindId
-  bindLabel = _aBindLabel
-
-type Def t a = (AnnBind t a, Expr t a)
-
--- TODO: better name
--- | A typeclass for filling in a missing annotation.
-class Unannotated t where
-  missingAnnotation :: t
-
-instance Unannotated (ParsedType r a) where
-  missingAnnotation = ParsedInfer
-
-instance Unannotated (AnfType t a) where
-  missingAnnotation = Nothing
-
--- | Constructing `Bare` from let-binds
-bindsExpr :: (Unannotated t) => [(Bind a, (Expr t a))] -> Expr t a -> a -> Expr t a
-bindsExpr bs e l = foldr (\(x, e1) e2 ->
-                            Let (annotateBinding x missingAnnotation) e1 e2 l)
-                   e bs
-
-annotateBinding :: Bind a -> t -> AnnBind t a
-annotateBinding bind typ =
-  AnnBind { _aBindId = bindId bind
-          , _aBindType = typ
-          , _aBindLabel = bindLabel bind
-          }
-
--- | Constructing a function declaration
+-- -- | Constructing a function declaration
 -- dec :: Bind a -> Sig -> [Bind a] -> Expr a -> Expr a -> a -> Expr a
 -- dec f t xs e e' l = Let f (Fun f t xs e l) e' l
 
@@ -205,36 +234,36 @@ annotateBinding bind typ =
 --       where (bs, body) = go e'
 --     go body = ([], body)
 
---------------------------------------------------------------------------------
-extract :: Expr t a -> a
---------------------------------------------------------------------------------
-extract (Number _ l)    = l
-extract (Boolean _ l)   = l
-extract (Id _ l)        = l
-extract (Prim _ l)      = l
-extract (If _ _ _ l)    = l
-extract (Let _ _ _ l)   = l
-extract (App _ _ l)     = l
-extract (Lam _ _ l)     = l
-extract (Unit  l)       = l
-extract (TApp _ _ l)    = l
-extract (TAbs _ _ l)    = l
+extractLoc :: Expr t a -> a
+extractLoc (AnnNumber _ _ l)    = l
+extractLoc (AnnBoolean _ _ l)   = l
+extractLoc (AnnId _ _ l)        = l
+extractLoc (AnnPrim _ _ l)      = l
+extractLoc (AnnIf _ _ _ _ l)    = l
+extractLoc (AnnLet _ _ _ _ l)   = l
+extractLoc (AnnApp _ _ _ l)     = l
+extractLoc (AnnLam _ _ _ l)     = l
+extractLoc (AnnUnit _ l)        = l
+extractLoc (AnnTApp _ _ _ l)    = l
+extractLoc (AnnTAbs _ _ _ l)    = l
 
---------------------------------------------------------------------------------
--- | Dynamic Errors
---------------------------------------------------------------------------------
-
--- | DynError correspond to different kind of dynamic/run-time errors
-data DynError
-  = ArithOverflow
-  | IndexLow
-  | IndexHigh
-  | ArityError
-  deriving (Show)
+extractAnn :: Expr t a -> t
+extractAnn (AnnNumber _ t _)    = t
+extractAnn (AnnBoolean _ t _)   = t
+extractAnn (AnnId _ t _)        = t
+extractAnn (AnnPrim _ t _)      = t
+extractAnn (AnnIf _ _ _ t _)    = t
+extractAnn (AnnLet _ _ _ t _)   = t
+extractAnn (AnnApp _ _ t _)     = t
+extractAnn (AnnLam _ _ t _)     = t
+extractAnn (AnnUnit t _)        = t
+extractAnn (AnnTApp _ _ t _)    = t
+extractAnn (AnnTAbs _ _ t _)    = t
 
 --------------------------------------------------------------------------------
 -- | Pretty Printer
 --------------------------------------------------------------------------------
+
 instance PPrint Prim where
   pprint Plus    = "+"
   pprint Minus   = "-"
@@ -249,40 +278,44 @@ instance PPrint Bool where
   pprint True  = "True"
   pprint False = "False"
 
+instance PPrint () where
+  pprint () = ""
+
+instance PPrint a => PPrint (Maybe a) where
+  pprint Nothing = ""
+  pprint (Just a) = pprint a
+
 -- TODO: properly print annotations
-instance PPrint (Bind a) where
-  pprint (Bind x _) = x
+instance (PPrint t) => PPrint (Bind t a) where
+  pprint (AnnBind x tag _) = printf "%s %s" x (pprint tag)
 
-instance (PPrint t) => PPrint (AnnBind t a) where
-  pprint (AnnBind x typ _) = printf "(%s : %s)" x (pprint typ)
+instance (PPrint r) => PPrint (ElaboratedAnnotation r a) where
+  pprint (ElabRefined rtype) = printf ": %s" (pprint rtype)
+  pprint (ElabUnrefined typ) = printf ": %s" (pprint typ)
 
-instance (PPrint r) => PPrint (ElaboratedType r a) where
-  pprint (Left rtype) = printf ": %s" (pprint rtype)
-  pprint (Right typ) = printf ": %s" (pprint typ)
-
-instance (PPrint r) => PPrint (ParsedType r a) where
+instance (PPrint r) => PPrint (ParsedAnnotation r a) where
   pprint (ParsedCheck rtype) = printf ": %s" (pprint rtype)
   pprint (ParsedAssume rtype) = printf "as %s" (pprint rtype)
   pprint ParsedInfer = ""
 
 -- TODO: better instance
 instance (PPrint t) => PPrint (Expr t a) where
-  pprint (Number n _) = show n
-  pprint (Boolean b _) = pprint b
-  pprint (Unit _) = "()"
-  pprint (Id x _) = x
-  pprint (Prim o _) = printf "%s" (pprint o)
-  pprint (If c t e _) = printf "(if %s then %s else %s)" (pprint c) (pprint t) (pprint e)
-  -- pprint e@Let{} = printf "(let %s in %s)" (ppDefs ds) (pprint e')
-  --   where (ds, e') = exprDefs e
-  pprint (Let bind e1 e2 _) = printf "(let %s = %s in %s)" (ppDef bind) (pprint e1) (pprint e2)-- TODO: make better
-  pprint (App e1 e2 _) = printf "(%s %s)" (pprint e1) (pprint e2)
-  pprint (Lam x e _) = printf "(\\ %s -> %s)" (ppDef x) (pprint e)
-  pprint (TApp e t _) = printf "(%s@%s)" (pprint e) (pprint t)
-  pprint (TAbs alpha e _) = printf "(/\\%s . %s)" (pprint alpha) (pprint e)
+  pprint (AnnNumber n _ _) = show n
+  pprint (AnnBoolean b _ _) = pprint b
+  pprint (AnnUnit _ _) = "()"
+  pprint (AnnId x _ _) = x
+  pprint (AnnPrim o _ _) = printf "%s" (pprint o)
+  pprint (AnnIf c t e _ _) = printf "(if %s then %s else %s)" (pprint c) (pprint t) (pprint e)
+  -- pprinAnnt e@Let{} = printf "(let %s in %s)" (ppDefs ds) (pprint e')
+  --   wheAnnre (ds, e') = exprDefs e
+  pprint (AnnLet bind e1 e2 _ _) = printf "(let %s = %s in %s)" (ppDef bind) (pprint e1) (pprint e2)-- TODO: make better
+  pprint (AnnApp e1 e2 _ _) = printf "(%s %s)" (pprint e1) (pprint e2)
+  pprint (AnnLam x e _ _) = printf "(\\ %s -> %s)" (ppDef x) (pprint e)
+  pprint (AnnTApp e t _ _) = printf "(%s@%s)" (pprint e) (pprint t)
+  pprint (AnnTAbs alpha e _ _) = printf "(/\\%s . %s)" (pprint alpha) (pprint e)
 
-ppDef :: (PPrint t) => AnnBind t a -> Text
-ppDef annBind = printf "%s %s" (bindId annBind) (pprint $ aBindType annBind)
+ppDef :: (PPrint t) => Bind t a -> Text
+ppDef annBind = printf "%s%s" (bindId annBind) (pprint $ bindAnn annBind)
 
 _ppSig k b s = printf "%s %s %s\n" (pprint b) k (pprint s)
 _ppEqn b e = printf "%s = \n" (pprint b)
@@ -294,7 +327,7 @@ nest n = unlines . map pad . lines
     pad s = blanks ++ s
     blanks = replicate n ' '
 
-instance PPrint e => PPrint (RType e a) where
+instance (PPrint r) => PPrint (RType r a) where
   pprint (RBase b t e) =
     printf "{%s:%s | %s}" (pprint b) (pprint t) (pprint e)
   pprint (RFun b t1 t2) =
@@ -305,59 +338,19 @@ instance PPrint e => PPrint (RType e a) where
     printf "{%s:%s || %s}" (pprint b) (pprint t) (pprint e)
   pprint (RForall tv t) = printf "forall %s. %s" (pprint tv) (pprint t)
 
-type AnfExpr r a = Expr (AnfType r a) a
-
-type ImmExpr r a = Expr (AnfType r a) a
 --------------------------------------------------------------------------------
 -- | The `Parsed` types are for parsed ASTs.
 --------------------------------------------------------------------------------
 
 instance Located a => Located (Expr t a) where
-  sourceSpan e = sourceSpan $ extract e
+  sourceSpan e = sourceSpan $ extractLoc e
 
-instance Located a => Located (AnnBind t a) where
-  sourceSpan bind = sourceSpan $ bindLabel bind
-
-instance Located a => Located (Bind a) where
-  sourceSpan bind = sourceSpan $ bindLabel bind
+instance Located a => Located (Bind t a) where
+  sourceSpan bind = sourceSpan $ bindTag bind
 
 --------------------------------------------------------------------------------
 -- | Types ---------------------------------------------------------------------
 --------------------------------------------------------------------------------
-
--- | Refinement types
--- | - refinements are expressions of type Bool
--- |
--- | ```
--- | τ ::= { v:τ | r }   -- a refinement on an RType
--- |     | { v:b | r }   -- a refinement on a base Type
--- |     | x:τ -> τ      -- a pi type
--- |     | ∀a.τ
--- | ```
--- |
--- | This allows us to bind functions as in LH `--higherorder`
--- |   {f : { v:_ | v < 0 } -> { v:_ | v > 0} | f 0 = 0}
-
-data RType r a
-  = RBase !(Bind a) Type !r
-  | RFun !(Bind a) !(RType r a) !(RType r a)
-  | RIFun !(Bind a) !(RType r a) !(RType r a)
-  | RRTy !(Bind a) !(RType r a) r
-  | RForall TVar !(RType r a)
-  deriving (Show, Functor, Read)
-
-data Type = TVar TVar           -- a
-          | TUnit               -- 1
-          | TInt                -- Int
-          | TBool               -- Bool
-          | Type :=> Type       -- t1 => t2
-          | TCtor Ctor [Type]   -- Ctor [t1,...,tn]
-          | TForall TVar Type   -- ∀a.t
-          deriving (Eq, Ord, Show, Read)
-
-newtype Ctor = CT Id deriving (Eq, Ord, Show, Read)
-
-newtype TVar = TV Id deriving (Eq, Ord, Show, Read)
 
 unTV :: TVar -> Id
 unTV (TV t) = t
@@ -413,11 +406,11 @@ prTVar (TV a) = PP.text a
 --------------------------------------------------------------------------------
 
 -- | NNF Constraints
-data Constraint r
+data NNF r
   = Head r                             -- ^ p
-  | CAnd [Constraint r]                -- ^ c1 /\ c2
-  | All Id Type r (Constraint r)       -- ^ ∀x:τ.p => c
-  | Any Id Type r (Constraint r)       -- ^ :x:τ.p => c
+  | CAnd [NNF r]                -- ^ c1 /\ c2
+  | All Id Type r (NNF r)       -- ^ ∀x:τ.p => c
+  | Any Id Type r (NNF r)       -- ^ :x:τ.p => c
   deriving (Show, Functor, Eq)
 
 -- | Type class to represent predicates
@@ -464,32 +457,37 @@ instance MonadFresh m => MonadFresh (ContT r m) where
   refreshId = lift . refreshId
 
 -------------------------------------------------------------------------------
--- Bifunctor instances --------------------------------------------------------
+-- Mist AST instances ---------------------------------------------------------
 -------------------------------------------------------------------------------
 
 instance Bifunctor Expr where
   second = fmap
-  first _ (Number i l) = Number i l
-  first _ (Boolean b l) = Boolean b l
-  first _ (Unit l) = Unit l
-  first _ (Id x l) = Id x l
-  first _ (Prim op l) = Prim op l
-  first f (If e1 e2 e3 l) = If (first f e1) (first f e2) (first f e3) l
-  first f (Let bind e1 e2 l) = Let (first f bind) (first f e1) (first f e2) l
-  first f (App e1 e2 l) = App (first f e1) (first f e2) l
-  first f (Lam bind e l) = Lam (first f bind) (first f e) l
-  first f (TApp e t l) = TApp (first f e) t l
-  first f (TAbs alpha e l) = TAbs alpha (first f e) l
+  first f (AnnNumber i ann l) = AnnNumber i (f ann) l
+  first f (AnnBoolean b ann l) = AnnBoolean b (f ann) l
+  first f (AnnUnit ann l) = AnnUnit (f ann) l
+  first f (AnnId x ann l) = AnnId x (f ann) l
+  first f (AnnPrim op ann l) = AnnPrim op (f ann) l
+  first f (AnnIf e1 e2 e3 ann l) = AnnIf (first f e1) (first f e2) (first f e3) (f ann) l
+  first f (AnnLet bind e1 e2 ann l) = AnnLet (first f bind) (first f e1) (first f e2) (f ann) l
+  first f (AnnApp e1 e2 ann l) = AnnApp (first f e1) (first f e2) (f ann) l
+  first f (AnnLam bind e ann l) = AnnLam (first f bind) (first f e) (f ann) l
+  first f (AnnTApp e t ann l) = AnnTApp (first f e) t (f ann) l
+  first f (AnnTAbs alpha e ann l) = AnnTAbs alpha (first f e) (f ann) l
 
-instance Bifunctor AnnBind where
+instance Bifunctor Bind where
   second = fmap
-  first f a@AnnBind{_aBindType = typ} = a{_aBindType = f typ}
+  first f a@AnnBind{bindAnn = ann} = a{bindAnn = f ann}
 
-instance Bifunctor ParsedType where
+instance Bifunctor ParsedAnnotation where
   second = fmap
   first f (ParsedCheck r) = ParsedCheck $ first f r
   first f (ParsedAssume r) = ParsedAssume $ first f r
   first _ ParsedInfer = ParsedInfer
+
+instance Bifunctor ElaboratedAnnotation where
+  second = fmap
+  first f (ElabRefined r) = ElabRefined $ first f r
+  first _ (ElabUnrefined typ) = ElabUnrefined typ
 
 instance Bifunctor RType where
   second = fmap
@@ -498,3 +496,12 @@ instance Bifunctor RType where
   first f (RIFun b rt1 rt2) = RIFun b (first f rt1) (first f rt2)
   first f (RRTy b rt r) = RRTy b (first f rt) (f r)
   first f (RForall tvar rt) = RForall tvar (first f rt)
+
+class Default a where
+  defaultVal :: a
+
+instance Default () where
+  defaultVal = ()
+
+instance Default (Maybe a) where
+  defaultVal = Nothing

--- a/lib/Language/Mist/Types.hs
+++ b/lib/Language/Mist/Types.hs
@@ -47,7 +47,6 @@ module Language.Mist.Types
 
   , extractLoc, extractAnn
   , unTV
-  , bindsExpr
 
   , eraseRType
 
@@ -213,9 +212,6 @@ type ElaboratedBind r a = Bind (Maybe (ElaboratedAnnotation r a)) a
 
 type AnfExpr t a = Expr t a
 type ImmExpr t a = Expr t a
-
-bindsExpr :: [(Bind t a, Expr t a)] -> Expr t a -> t -> a -> Expr t a
-bindsExpr bs e t l = foldr (\(x, e1) e2 -> AnnLet x e1 e2 t l) e bs
 
 -- -- | Constructing a function declaration
 -- dec :: Bind a -> Sig -> [Bind a] -> Expr a -> Expr a -> a -> Expr a

--- a/lib/Language/Mist/Types.hs
+++ b/lib/Language/Mist/Types.hs
@@ -114,6 +114,8 @@ data Bind t a = AnnBind
   }
   deriving (Show, Functor, Eq)
 
+{-# COMPLETE Number, Boolean, Unit, Id, Prim, If, Let, Lam, App, TApp, TAbs #-}
+
 pattern Number :: (Default t) => Integer -> a -> Expr t a
 pattern Number n l <- AnnNumber n _ l
   where Number n l = AnnNumber n defaultVal l
@@ -147,6 +149,8 @@ pattern TApp e typ l <- AnnTApp e typ _ l
 pattern TAbs :: (Default t) => TVar -> Expr t a -> a -> Expr t a
 pattern TAbs tvar e l <- AnnTAbs tvar e _ l
   where TAbs tvar e l = AnnTAbs tvar e defaultVal l
+
+{-# COMPLETE Bind #-}
 
 pattern Bind :: (Default t) => Id -> a -> Bind t a
 pattern Bind id tag <- AnnBind id _ tag

--- a/lib/Language/Mist/Types.hs
+++ b/lib/Language/Mist/Types.hs
@@ -46,6 +46,7 @@ module Language.Mist.Types
   , Prim (..)
 
   , extractLoc, extractAnn
+  , putAnn
   , unTV
 
   , eraseRType
@@ -259,6 +260,19 @@ extractAnn (AnnLam _ _ t _)     = t
 extractAnn (AnnUnit t _)        = t
 extractAnn (AnnTApp _ _ t _)    = t
 extractAnn (AnnTAbs _ _ t _)    = t
+
+putAnn :: t -> Expr t a -> Expr t a
+putAnn t (AnnNumber n _ l) = AnnNumber n t l
+putAnn t (AnnBoolean b _ l) = AnnBoolean b t l
+putAnn t (AnnId x _ l) = AnnId x t l
+putAnn t (AnnPrim p _ l) = AnnPrim p t l
+putAnn t (AnnIf e1 e2 e3 _ l) = AnnIf e1 e2 e3 t l
+putAnn t (AnnLet x e1 e2 _ l) = AnnLet x e1 e2 t l
+putAnn t (AnnApp e1 e2 _ l) = AnnApp e1 e2 t l
+putAnn t (AnnLam x e _ l) = AnnLam x e t l
+putAnn t (AnnUnit _ l) = AnnUnit t l
+putAnn t (AnnTApp e typ _ l) = AnnTApp e typ t l
+putAnn t (AnnTAbs tvar e _ l) = AnnTAbs tvar e t l
 
 --------------------------------------------------------------------------------
 -- | Pretty Printer

--- a/mist.cabal
+++ b/mist.cabal
@@ -71,7 +71,8 @@ test-suite test
                     tasty-ant-xml,
                     text,
                     megaparsec,
-                    mist
+                    mist,
+                    liquid-fixpoint
   other-modules:    Tests.Utils,
                     Tests.Integration.Tests,
                     Tests.Language.Mist.Names

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - tasty-rerun-1.1.12
 # liquid-fixpoint and deps
 - github: ucsd-progsys/liquid-fixpoint
-  commit: 13c01e3d152e30bb1d8a42a81484e3fa38afbe62
+  commit: abb35956cde1ab7c194b9b63e0d6ec977fbab754
 - dotgen-0.4.2
 - fgl-visualize-0.1.0.1
 - intern-0.9.2

--- a/tests/Tests/Language/Mist/CGen.hs
+++ b/tests/Tests/Language/Mist/CGen.hs
@@ -8,37 +8,18 @@ import Test.Tasty.HUnit
 import Tests.Utils
 import Tests.SimpleTypes
 
+import qualified Language.Fixpoint.Types as F
+import qualified Language.Fixpoint.Horn.Types as HC
+
 import Data.Bifunctor
 
 import Language.Mist.Types (Predicate (..), MonadFresh (..), Constraint (..))
 import qualified Language.Mist.Types as T
 import Language.Mist.CGen
 import Language.Mist.Names
-import Language.Mist.Checker (primToUnpoly)
+import Language.Mist.ToFixpoint
 
-type P = Expr () ()
-
-instance Predicate P where
-  true = Boolean True
-  false = Boolean False
-  varsEqual x y = Prim2 Equal (Id x) (Id y)
-  strengthen e1 e2 = Prim2 And e1 e2
-  buildKvar x params = foldr (\arg kvar -> App kvar (Id arg)) (Id x) params
-  varSubst x y e = subst1 @P @P (Id x) y e
-  var x = Id x
-  varNot x = error "TODO"
-  prim e@T.Unit{} = equalityPrim e TUnit
-  prim e@T.Number{} = equalityPrim e TInt
-  prim e@T.Boolean{} = equalityPrim e TBool
-  prim e@(T.Prim2 op _ _ _) = equalityPrim e (primToUnpoly op)
-  prim _ = error "prim on non primitive"
-
-equalityPrim :: (MonadFresh m) => Expr t a -> Type -> m (RType P a)
-equalityPrim e typ = do
-  let loc = T.extract e
-  vv <- refreshId $ "VV" ++ cSEPARATOR
-  let e' = (second $ const ()) ((first $ const ()) e)
-  pure $ T.RBase (T.Bind vv loc) typ (Prim2 Equal (Id vv) e')
+type P = HC.Pred
 
 cgenTests = testGroup "cgen"
   [

--- a/tests/Tests/Language/Mist/CGen.hs
+++ b/tests/Tests/Language/Mist/CGen.hs
@@ -13,7 +13,7 @@ import qualified Language.Fixpoint.Horn.Types as HC
 
 import Data.Bifunctor
 
-import Language.Mist.Types (Predicate (..), MonadFresh (..), Constraint (..))
+import Language.Mist.Types (Predicate (..), MonadFresh (..), NNF (..))
 import qualified Language.Mist.Types as T
 import Language.Mist.CGen
 import Language.Mist.Names

--- a/tests/Tests/Language/Mist/Checker.hs
+++ b/tests/Tests/Language/Mist/Checker.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-module Tests.Language.Mist.Checker (checkerTests) where
+{-# LANGUAGE PatternSynonyms #-}
 
-import Debug.Trace
+module Tests.Language.Mist.Checker (checkerTests) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -9,13 +9,14 @@ import Test.Tasty.HUnit
 import Data.Either (isRight, isLeft)
 import Text.Printf
 
-import Tests.Utils
+import Tests.Utils ()
 import Tests.SimpleTypes
 
 import Language.Mist.Checker
 import Language.Mist.UX (Result)
 
-type ElabResult = Result (ElaboratedExpr (ElaboratedType () ()) ())
+
+type ElabResult = Result (ElaboratedExpr (Expr () ()) ())
 
 noPred = ()
 
@@ -36,23 +37,15 @@ checkerTests = testGroup "Language.Mist.Checker"
 elaborationTests = testGroup "elaborate"
   [
     testCase "let id : A -> A = λx.x in ()" $
-    let result
-          = elaborate (Let
-                       (AnnBind "id" (ParsedCheck (RForall (TV "A") (toRBase $ "A" ==> "A"))))
-                       (Lam (AnnBind "x" ParsedInfer) (Id "x"))
-                       Unit)
+    let result = elaborate e1
     in shouldCheck result
 
   , testCase "λx.y" $
-    let result :: ElabResult = elaborate (Lam (AnnBind "x" ParsedInfer) (Id "y"))
+    let result :: ElabResult = elaborate (Lam (AnnBind "x" (Just ParsedInfer)) (Id "y"))
     in shouldFail result
 
   , testCase "let id : (ASSUME A -> A) = () in ()" $
-    let result
-          = elaborate (Let
-                       (AnnBind "id" (ParsedAssume (RForall (TV "A") (toRBase $ "A" ==> "A"))))
-                       Unit
-                       Unit)
+    let result = elaborate e2
     in shouldCheck result
 
   , testGroup "let id : A -> A = λx.x in id 1" $
@@ -60,10 +53,7 @@ elaborationTests = testGroup "elaborate"
                        _
                        (TAbs (TV "A") _)
                        (App (TApp (Id "id") TInt) (Number 1))))
-          = elaborate (Let
-                       (AnnBind "id" (ParsedCheck (RForall (TV "A") (toRBase $ "A" ==> "A"))))
-                       (Lam (AnnBind "x" ParsedInfer) (Id "x"))
-                       (App (Id "id") (Number 1)))
+          = elaborate e3
     in [ testCase "type checks" $ shouldCheck result
        ]
 
@@ -77,13 +67,7 @@ elaborationTests = testGroup "elaborate"
                          (App (App (TApp (TApp (Id "map") TInt) TInt)
                                (TApp (Id "id") TInt))
                            (Number 1)))))
-          = elaborate (Let
-                       (AnnBind "id" (ParsedAssume (RForall (TV "A") (toRBase $ "A" ==> "A"))))
-                       Unit
-                       (Let
-                        (AnnBind "map" (ParsedCheck (RForall (TV "A") (RForall (TV "B") (toRBase $ ("A" ==> "B") :=> ("A" ==> "B"))))))
-                        (Lam (AnnBind "f" ParsedInfer) (Lam (AnnBind "x" ParsedInfer) (App (Id "f") (Id "x"))))
-                        (App (App (Id "map") (Id "id")) (Number 1))))
+          = elaborate e4
     in [ testCase "type checks" $ shouldCheck result
        ]
 
@@ -97,26 +81,17 @@ elaborationTests = testGroup "elaborate"
                         (App (App (TApp (TApp (Id "map") TUnit) TInt)
                                     (TApp (Id "const") TUnit))
                               Unit))))
-          = elaborate (Let
-                       (AnnBind "const" (ParsedAssume (RForall (TV "A") (toRBase $ (TVar $ TV "A") :=> TInt))))
-                       Unit
-                       (Let
-                        (AnnBind "map" (ParsedCheck (RForall (TV "A") (RForall (TV "B") (toRBase $ ("A" ==> "B") :=> ("A" ==> "B"))))))
-                        (Lam (AnnBind "f" ParsedInfer) (Lam (AnnBind "x" ParsedInfer) (App (Id "f") (Id "x"))))
-                        (App (App (Id "map") (Id "const")) Unit)))
+          = elaborate e5
     in [ testCase "type checks" $ shouldCheck result
        ]
 
   , testGroup "let id = λx.x in ()" $
     let result@(Right (Let
-                       (AnnBind _ (ElabUnrefined (TForall (TV a1) (TVar (TV a2) :=> TVar (TV a3)))))
+                       (AnnBind _ (Just (ElabUnrefined (TForall (TV a1) (TVar (TV a2) :=> TVar (TV a3))))))
                        (TAbs (TV a4) _)
                        _))
           :: ElabResult
-          = elaborate (Let
-                       (AnnBind "id" ParsedInfer)
-                       (Lam (AnnBind "x" ParsedInfer) (Id "x"))
-                       Unit)
+          = elaborate e6
     in [ testCase "type checks" $ shouldCheck result
        , testCase "inferred type variables" $ do
            assertEqual "a1 == a2" a1 a2
@@ -124,3 +99,44 @@ elaborationTests = testGroup "elaborate"
            assertEqual "a3 == a4" a3 a4
        ]
   ]
+-- | let id : A -> A = λx.x in ()
+e1 = Let
+     (AnnBind "id" (Just $ ParsedCheck (RForall (TV "A") (toRBase $ "A" ==> "A"))))
+     (Lam (AnnBind "x" (Just ParsedInfer)) (Id "x"))
+     Unit
+
+-- | let id : (ASSUME A -> A) = () in ()
+e2 = Let
+     (AnnBind "id" (Just $ ParsedAssume (RForall (TV "A") (toRBase $ "A" ==> "A"))))
+     Unit
+     Unit
+
+-- | let id : A -> A = λx.x in id 1
+e3 = Let
+     (AnnBind "id" (Just $ ParsedCheck (RForall (TV "A") (toRBase $ "A" ==> "A"))))
+     (Lam (AnnBind "x" (Just ParsedInfer)) (Id "x"))
+     (App (Id "id") (Number 1))
+
+-- | assume id : A -> A = () in let map : (A -> B) -> A -> B = λf.λx.f x in map id 1
+e4 = Let
+     (AnnBind "id" (Just $ ParsedAssume (RForall (TV "A") (toRBase $ "A" ==> "A"))))
+     Unit
+     (Let
+       (AnnBind "map" (Just $ ParsedCheck (RForall (TV "A") (RForall (TV "B") (toRBase $ ("A" ==> "B") :=> ("A" ==> "B"))))))
+       (Lam (AnnBind "f" (Just ParsedInfer)) (Lam (AnnBind "x" (Just ParsedInfer)) (App (Id "f") (Id "x"))))
+       (App (App (Id "map") (Id "id")) (Number 1)))
+
+-- | assume const : A -> Int = () in let map : (A -> B) -> A -> B = λf.λx.f x in map const ()
+e5 = Let
+     (AnnBind "const" (Just $ ParsedAssume (RForall (TV "A") (toRBase $ (TVar $ TV "A") :=> TInt))))
+     Unit
+     (Let
+       (AnnBind "map" (Just $ ParsedCheck (RForall (TV "A") (RForall (TV "B") (toRBase $ ("A" ==> "B") :=> ("A" ==> "B"))))))
+       (Lam (AnnBind "f" (Just ParsedInfer)) (Lam (AnnBind "x" (Just ParsedInfer)) (App (Id "f") (Id "x"))))
+       (App (App (Id "map") (Id "const")) Unit))
+
+-- let id = λx.x in ()
+e6 = Let
+     (AnnBind "id" (Just ParsedInfer))
+     (Lam (AnnBind "x" (Just ParsedInfer)) (Id "x"))
+     Unit

--- a/tests/Tests/Language/Mist/Names.hs
+++ b/tests/Tests/Language/Mist/Names.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module Tests.Language.Mist.Names (namesTests) where
 
 import Test.Tasty
@@ -15,12 +16,12 @@ namesTests = testGroup "Language.Mist.Names"
 refreshTests = testGroup "refresh"
   [
     testCase "uniquify λx.x" $
-    let (Lam (AnnBind x1 TInt) (Id x2)) = uniquify (Lam (AnnBind "x" TInt) (Id "x"))
+    let (Lam (Bind x1) (Id x2)) :: Expr () () = uniquify (Lam (Bind "x") (Id "x"))
     in x1 @=? x2
 
   , testGroup "uniquify λx.(λx.x)" $
-    let (Lam (AnnBind x1 TInt) (Lam (AnnBind x2 TInt) (Id x3))) =
-          uniquify (Lam (AnnBind "x" TInt) (Lam (AnnBind "x" TInt) (Id "x")))
+    let (Lam (Bind x1) (Lam (Bind x2) (Id x3))) :: Expr () () =
+          uniquify (Lam (Bind "x") (Lam (Bind "x") (Id "x")))
     in [ testCase "λ_.(λx2.x2)" $ x2 @=? x3
        , testCase "λx1.(λx2._)" $ x1 @/=? x2
        , testCase "λx1.(λ_.x2)" $ x1 @/=? x3

--- a/tests/Tests/SimpleTypes.hs
+++ b/tests/Tests/SimpleTypes.hs
@@ -10,30 +10,38 @@ module Tests.SimpleTypes
   -- -- * Abstract syntax of Mist
   , T.Expr
   , pattern Number
+  , pattern AnnNumber
   , pattern Boolean
+  , pattern AnnBoolean
   , pattern Unit
+  , pattern AnnUnit
   , pattern Id
+  , pattern AnnId
   , pattern Prim
+  , pattern AnnPrim
   , pattern If
+  , pattern AnnIf
   , pattern Let
+  , pattern AnnLet
   , pattern App
+  , pattern AnnApp
   , pattern Lam
+  , pattern AnnLam
   , pattern TApp
+  , pattern AnnTApp
   , pattern TAbs
+  , pattern AnnTAbs
 
-  , T.ParsedType (..)
-  , T.ParsedExpr, T.ParsedAnnBind, T.ParsedDef
+  , T.ParsedAnnotation (..)
+  , T.ParsedExpr, T.ParsedBind
 
-  , T.ElaboratedType
+  , T.ElaboratedAnnotation
   , pattern T.ElabUnrefined, pattern T.ElabRefined
-  , T.ElaboratedExpr, T.ElaboratedAnnBind
+  , T.ElaboratedExpr, T.ElaboratedBind
 
   , T.Bind
   , pattern Bind
-
-  , T.AnnBind
   , pattern AnnBind
-
   ) where
 
 import qualified Language.Mist.Types as T
@@ -52,14 +60,23 @@ pattern Lam b e = T.Lam b e ()
 pattern TApp e t = T.TApp e t ()
 pattern TAbs alpha e = T.TAbs alpha e ()
 
-pattern Bind x = T.Bind { T._bindId = x
-                        , T._bindLabel = ()
-                        }
+pattern Bind x = T.Bind x ()
 
+pattern AnnNumber i tag = T.AnnNumber i tag ()
+pattern AnnBoolean b tag = T.AnnBoolean b tag ()
+pattern AnnUnit tag = T.AnnUnit tag ()
+pattern AnnId x tag = T.AnnId x tag ()
+pattern AnnPrim p tag = T.AnnPrim p tag ()
+pattern AnnIf e1 e2 e3 tag = T.AnnIf e1 e2 e3 tag ()
+pattern AnnLet b e1 e2 tag = T.AnnLet b e1 e2 tag ()
+pattern AnnApp e1 e2 tag = T.AnnApp e1 e2 tag ()
+pattern AnnLam b e tag = T.AnnLam b e tag ()
+pattern AnnTApp e t tag = T.AnnTApp e t tag ()
+pattern AnnTAbs alpha e tag = T.AnnTAbs alpha e tag ()
 
-pattern AnnBind x t = T.AnnBind { T._aBindId = x
-                                , T._aBindType = t
-                                , T._aBindLabel = ()}
+pattern AnnBind {bindId, bindAnn} = T.AnnBind{ T.bindId = bindId
+                                             , T.bindAnn = bindAnn
+                                             , T.bindTag = ()}
 
 instance UX.Located () where
   sourceSpan () = UX.SS

--- a/tests/Tests/SimpleTypes.hs
+++ b/tests/Tests/SimpleTypes.hs
@@ -2,7 +2,7 @@
 
 module Tests.SimpleTypes
   (
-    T.Prim2 (..)
+    T.Prim (..)
   , T.Id
   , T.Type (..), T.TVar (..), T.Ctor (..)
   , T.RType (..)
@@ -13,7 +13,7 @@ module Tests.SimpleTypes
   , pattern Boolean
   , pattern Unit
   , pattern Id
-  , pattern Prim2
+  , pattern Prim
   , pattern If
   , pattern Let
   , pattern App
@@ -34,7 +34,6 @@ module Tests.SimpleTypes
   , T.AnnBind
   , pattern AnnBind
 
-  , T.Field (..)
   ) where
 
 import qualified Language.Mist.Types as T
@@ -45,11 +44,9 @@ pattern Number i = T.Number i ()
 pattern Boolean b = T.Boolean b ()
 pattern Unit = T.Unit ()
 pattern Id x = T.Id x ()
-pattern Prim2 p e1 e2 = T.Prim2 p e1 e2 ()
+pattern Prim p = T.Prim p ()
 pattern If e1 e2 e3 = T.If e1 e2 e3 ()
 pattern Let b e1 e2 = T.Let b e1 e2 ()
--- pattern Tuple e1 e2 = T.GetItem e1 e2 ()
--- pattern GetItem e1 f = T.GetItem e1 f ()
 pattern App e1 e2 = T.App e1 e2 ()
 pattern Lam b e = T.Lam b e ()
 pattern TApp e t = T.TApp e t ()

--- a/tests/Tests/Utils.hs
+++ b/tests/Tests/Utils.hs
@@ -13,7 +13,3 @@ testGroupM n xs = testGroup n <$> sequence xs
 x @/=? y = (x /= y) @? msg
   where
     msg = "expected: " ++ show x ++ " /= " ++ show y ++ "\n but: " ++ show x ++ " == " ++ show y
-
-
-instance PPrint () where
-  pprint () = "()"


### PR DESCRIPTION
This change annotates each node with its type before running through ANF.

There are two syntax node patterns: `Ann*` and `*` (e.g. `AnnLet` and `Let`).
The `Ann*` forms have an extra field for the annotation information. The `*` forms are pattern synonyms when there is a default value that can be put in that field (generally `Nothing`).